### PR TITLE
Add draft editing flow and save action for body measurements

### DIFF
--- a/bot/handlers/body_params.py
+++ b/bot/handlers/body_params.py
@@ -56,6 +56,28 @@ MEASUREMENT_KEYS = [
 CARD_ORDER = ["date", *MEASUREMENT_KEYS]
 
 
+def _empty_values() -> dict[str, Any]:
+    """Возвращает словарь со всеми ключами окружностей, заполненный значениями None."""
+
+    return {"date": None, **{key: None for key in MEASUREMENT_KEYS}}
+
+
+def _draft_ready_for_save(draft: dict[str, Any] | None) -> bool:
+    """Проверяет, достаточно ли данных в черновике для отправки на сервер."""
+
+    if not isinstance(draft, dict):
+        return False
+
+    date = draft.get("date")
+    if not date:
+        return False
+
+    has_measurements = any(
+        draft.get(key) not in (None, "") for key in MEASUREMENT_KEYS
+    )
+    return has_measurements
+
+
 def _normalize_entries(payload: Any) -> list[dict[str, Any]]:
     """Приводит ответ API к списку словарей."""
 
@@ -213,9 +235,7 @@ def _build_card_text(values: dict[str, Any] | None, status: str | None = None) -
 def _store_entry(context: ContextTypes.DEFAULT_TYPE, entry: dict[str, Any] | None) -> dict[str, Any]:
     """Сохраняет текущие значения обмеров в контексте пользователя."""
 
-    values: dict[str, Any] = {"date": None}
-    for key in MEASUREMENT_KEYS:
-        values[key] = None
+    values = _empty_values()
 
     if entry:
         uuid = entry.get("uuid") or entry.get("id")
@@ -238,6 +258,8 @@ def _store_entry(context: ContextTypes.DEFAULT_TYPE, entry: dict[str, Any] | Non
         context.user_data.pop("body_params_uuid", None)
 
     context.user_data["body_params_values"] = values
+    context.user_data["body_params_draft"] = {**values}
+    context.user_data["body_params_dirty"] = False
     return values
 
 
@@ -306,8 +328,10 @@ async def _load_and_store(context: ContextTypes.DEFAULT_TYPE, token: str) -> tup
         values = _store_entry(context, entry)
     else:
         context.user_data.pop("body_params_uuid", None)
-        context.user_data["body_params_values"] = {"date": None, **{key: None for key in MEASUREMENT_KEYS}}
-        values = context.user_data["body_params_values"]
+        values = _empty_values()
+        context.user_data["body_params_values"] = values
+        context.user_data["body_params_draft"] = {**values}
+        context.user_data["body_params_dirty"] = False
     return values, error
 
 
@@ -323,20 +347,33 @@ async def _refresh_card(
     """Перерисовывает карточку с обмерами."""
 
     values: dict[str, Any] | None = None
-    has_data = False
     status_message = status
+    dirty = bool(context.user_data.get("body_params_dirty"))
+    has_saved_data = bool(context.user_data.get("body_params_uuid"))
 
-    if not skip_fetch and token:
+    if not skip_fetch and token and not dirty:
         values, error = await _load_and_store(context, token)
         if error and not status_message:
             status_message = f"❌ {html.escape(error)}"
-        has_data = bool(context.user_data.get("body_params_uuid"))
+        has_saved_data = bool(context.user_data.get("body_params_uuid"))
     else:
-        values = context.user_data.get("body_params_values")
-        has_data = bool(context.user_data.get("body_params_uuid"))
+        values = context.user_data.get("body_params_draft") or context.user_data.get("body_params_values")
+
+    if values is None:
+        values = _empty_values()
+
+    if dirty:
+        unsaved_hint = "💾 Черновик не сохранён."
+        if status_message:
+            if unsaved_hint not in status_message:
+                status_message = f"{status_message}\n{unsaved_hint}"
+        else:
+            status_message = unsaved_hint
+
+    can_save = dirty and _draft_ready_for_save(context.user_data.get("body_params_draft"))
 
     text = _build_card_text(values, status=status_message)
-    keyboard = get_body_params_menu(has_data=has_data)
+    keyboard = get_body_params_menu(has_data=has_saved_data, can_save=can_save)
 
     if message_id is not None:
         try:
@@ -367,7 +404,10 @@ async def _render_placeholder(
     """Отображает заглушку и сбрасывает сохранённые данные."""
 
     context.user_data.pop("body_params_uuid", None)
-    context.user_data["body_params_values"] = {"date": None, **{key: None for key in MEASUREMENT_KEYS}}
+    empty_values = _empty_values()
+    context.user_data["body_params_values"] = empty_values
+    context.user_data["body_params_draft"] = {**empty_values}
+    context.user_data["body_params_dirty"] = False
 
     message = getattr(query, "message", None)
     if not message:
@@ -424,15 +464,17 @@ async def show_body_params(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     status = f"❌ {html.escape(error)}" if error else None
 
     message = query.message
-    if not message:
-        return ConversationHandler.END
+    chat_id = message.chat_id if message else query.from_user.id
+    message_id = message.message_id if message else None
 
-    await message.edit_text(
-        _build_card_text(values, status=status),
-        parse_mode="HTML",
-        reply_markup=get_body_params_menu(has_data=bool(context.user_data.get("body_params_uuid"))),
+    await _refresh_card(
+        context,
+        chat_id=chat_id,
+        message_id=message_id,
+        token=None,
+        status=status,
+        skip_fetch=True,
     )
-    context.user_data["body_params_message"] = (message.chat_id, message.message_id)
     return ConversationHandler.END
 
 
@@ -480,7 +522,7 @@ async def prompt_body_param(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         )
         return ConversationHandler.END
 
-    values = context.user_data.get("body_params_values", {})
+    values = context.user_data.get("body_params_draft") or context.user_data.get("body_params_values", {})
 
     prompt_lines: list[str] = []
     if param_key == "date":
@@ -553,22 +595,6 @@ async def handle_body_param_input(update: Update, context: ContextTypes.DEFAULT_
         context.user_data.pop("current_state", None)
         return ConversationHandler.END
 
-    token = await get_valid_access_token(user_id)
-    if not token:
-        warning = await message.reply_text(
-            "🔐 Для сохранения замеров войдите через /login."
-        )
-        schedule_message_deletion(
-            context,
-            [user_message_id, warning.message_id],
-            chat_id,
-            delay=10,
-        )
-        context.user_data["conversation_active"] = False
-        context.user_data.pop("pending_body_param", None)
-        context.user_data.pop("current_state", None)
-        return ConversationHandler.END
-
     message_info = context.user_data.get("body_params_message")
     card_chat_id, card_message_id = (message_info or (chat_id, None))
 
@@ -586,7 +612,7 @@ async def handle_body_param_input(update: Update, context: ContextTypes.DEFAULT_
             context,
             chat_id=card_chat_id,
             message_id=card_message_id,
-            token=token,
+            token=None,
             status=status,
             skip_fetch=True,
         )
@@ -619,59 +645,244 @@ async def handle_body_param_input(update: Update, context: ContextTypes.DEFAULT_
             )
         payload_value = int(round(value)) if abs(value - round(value)) < 1e-4 else round(value, 1)
 
-    payload = {param_key: payload_value}
-    existing_values = context.user_data.get("body_params_values", {})
-    uuid = context.user_data.get("body_params_uuid")
+    draft = context.user_data.get("body_params_draft")
+    if not isinstance(draft, dict):
+        base = context.user_data.get("body_params_values")
+        draft = {**base} if isinstance(base, dict) else _empty_values()
 
-    try:
-        if uuid:
-            response = await api_update_body_params(token, uuid, payload)
-        else:
-            create_payload = {
-                field: existing_values.get(field)
-                for field in CARD_ORDER
-                if existing_values.get(field) not in (None, "")
-            }
-            create_payload.update(payload)
-            response = await api_create_body_params(token, create_payload)
-    except httpx.HTTPError as exc:  # noqa: BLE001
-        logger.error("Ошибка HTTP при сохранении обмеров: %s", exc)
-        return await _abort_with_error(
-            "❌ Не удалось отправить данные. Попробуйте позже.",
-            "❌ Не удалось сохранить значение. Попробуйте позже.",
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Неожиданная ошибка при сохранении обмеров: %s", exc)
-        return await _abort_with_error(
-            "❌ Произошла ошибка при сохранении параметров.",
-            "❌ Не удалось сохранить значение. Попробуйте позже.",
-        )
+    updated_draft = {**draft, param_key: payload_value}
+    context.user_data["body_params_draft"] = updated_draft
 
-    if response.status_code >= 400:
-        error_text = _extract_error_message(response) or "Не удалось сохранить параметр."
-        return await _abort_with_error(
-            f"⚠️ {error_text}",
-            f"❌ {html.escape(error_text)}",
+    saved_values = context.user_data.get("body_params_values")
+    is_dirty = True
+    if isinstance(saved_values, dict):
+        is_dirty = any(
+            saved_values.get(field) != updated_draft.get(field)
+            for field in CARD_ORDER
         )
+    context.user_data["body_params_dirty"] = is_dirty
 
-    status_message = (
-        "✅ Дата замеров обновлена."
-        if param_key == "date"
-        else f"✅ Значение «{FIELD_TITLES[param_key]}» сохранено."
-    )
+    if not is_dirty:
+        status_message = "ℹ️ Изменений нет — значения совпадают с сохранёнными."
+    else:
+        status_message = (
+            "✏️ Дата замеров обновлена в черновике."
+            if param_key == "date"
+            else f"✏️ «{FIELD_TITLES[param_key]}» обновлено в черновике."
+        )
 
     await _refresh_card(
         context,
         chat_id=card_chat_id,
         message_id=card_message_id,
-        token=token,
+        token=None,
         status=status_message,
+        skip_fetch=True,
     )
 
     schedule_message_deletion(context, [user_message_id], chat_id, delay=5)
     context.user_data["conversation_active"] = False
     context.user_data.pop("pending_body_param", None)
     context.user_data.pop("current_state", None)
+    return ConversationHandler.END
+
+
+async def cancel_body_param_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Отменяет ввод параметра тела, сохраняя черновик."""
+
+    message = update.message
+    if message is None:
+        return ConversationHandler.END
+
+    chat_id = message.chat_id
+    message_id = message.message_id
+
+    message_info = context.user_data.get("body_params_message")
+    card_chat_id, card_message_id = message_info or (chat_id, None)
+
+    await _refresh_card(
+        context,
+        chat_id=card_chat_id,
+        message_id=card_message_id,
+        token=None,
+        status="ℹ️ Ввод отменён.",
+        skip_fetch=True,
+    )
+
+    schedule_message_deletion(context, [message_id], chat_id, delay=5)
+    context.user_data["conversation_active"] = False
+    context.user_data.pop("pending_body_param", None)
+    context.user_data.pop("current_state", None)
+    return ConversationHandler.END
+
+
+async def save_body_params(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Сохраняет черновик замеров тела в Gym-Stat."""
+
+    query = update.callback_query
+    if not query:
+        logger.warning("save_body_params вызван без callback_query")
+        return ConversationHandler.END
+
+    await query.answer()
+    user_id = query.from_user.id
+
+    context.user_data.pop("pending_body_param", None)
+    context.user_data.pop("current_state", None)
+    context.user_data["conversation_active"] = False
+
+    draft = context.user_data.get("body_params_draft")
+    dirty = bool(context.user_data.get("body_params_dirty"))
+
+    message = query.message
+    message_info = context.user_data.get("body_params_message")
+    card_chat_id, card_message_id = (
+        message_info
+        or ((message.chat_id if message else user_id), None)
+    )
+
+    if not dirty:
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=None,
+            status="ℹ️ Нет изменений для сохранения.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    if not _draft_ready_for_save(draft):
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=None,
+            status="⚠️ Укажите дату и хотя бы одну окружность, чтобы сохранить запись.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    mode = await get_user_mode(user_id)
+    if mode != "api":
+        await _render_placeholder(
+            query,
+            context,
+            (
+                "🌐 <b>Только для режима Gym-Stat</b>\n"
+                "Переключитесь на интеграцию, чтобы сохранить измерения."
+            ),
+        )
+        return ConversationHandler.END
+
+    token = await get_valid_access_token(user_id)
+    if not token:
+        await _render_placeholder(
+            query,
+            context,
+            (
+                "🔐 <b>Нет активной сессии</b>\n"
+                "Авторизуйтесь через /login, чтобы продолжить."
+            ),
+        )
+        return ConversationHandler.END
+
+    payload = {
+        field: draft.get(field)
+        for field in CARD_ORDER
+        if isinstance(draft, dict) and draft.get(field) not in (None, "")
+    }
+
+    uuid = context.user_data.get("body_params_uuid")
+    is_update = bool(uuid)
+
+    try:
+        if uuid:
+            response = await api_update_body_params(token, uuid, payload)
+        else:
+            response = await api_create_body_params(token, payload)
+    except httpx.HTTPError as exc:  # noqa: BLE001
+        logger.error("Ошибка HTTP при сохранении обмеров: %s", exc)
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=None,
+            status="❌ Не удалось отправить данные. Попробуйте позже.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Неожиданная ошибка при сохранении обмеров: %s", exc)
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=None,
+            status="❌ Произошла ошибка при сохранении параметров.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    if response.status_code >= 400:
+        error_text = _extract_error_message(response) or "Не удалось сохранить запись."
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=None,
+            status=f"❌ {html.escape(error_text)}",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    new_entry: dict[str, Any] | None = None
+    try:
+        payload_data = response.json()
+    except ValueError:
+        payload_data = None
+
+    if payload_data is not None:
+        entries = _normalize_entries(payload_data)
+        if entries:
+            new_entry = max(entries, key=_entry_sort_key)
+
+    if new_entry:
+        _store_entry(context, new_entry)
+    else:
+        cleaned_values = _empty_values()
+        if isinstance(draft, dict):
+            for field in CARD_ORDER:
+                value = draft.get(field)
+                if value not in (None, ""):
+                    cleaned_values[field] = value
+        context.user_data["body_params_values"] = cleaned_values
+        context.user_data["body_params_draft"] = {**cleaned_values}
+        context.user_data["body_params_dirty"] = False
+        if uuid:
+            context.user_data["body_params_uuid"] = uuid
+
+    saved_uuid = context.user_data.get("body_params_uuid")
+    if not saved_uuid and isinstance(new_entry, dict):
+        extracted_uuid = new_entry.get("uuid") or new_entry.get("id")
+        if extracted_uuid:
+            context.user_data["body_params_uuid"] = extracted_uuid
+
+    status_message = (
+        "✅ Запись обмеров обновлена."
+        if is_update
+        else "✅ Запись обмеров создана."
+    )
+
+    await _refresh_card(
+        context,
+        chat_id=card_chat_id,
+        message_id=card_message_id,
+        token=None,
+        status=status_message,
+        skip_fetch=True,
+    )
+
     return ConversationHandler.END
 
 
@@ -767,9 +978,12 @@ async def delete_body_params(update: Update, context: ContextTypes.DEFAULT_TYPE)
         )
         return ConversationHandler.END
 
-    # После успешного удаления сбрасываем сохранённые значения
+    # После успешного удаления сбрасываем сохранённые значения и черновик
     context.user_data.pop("body_params_uuid", None)
-    context.user_data["body_params_values"] = {"date": None, **{key: None for key in MEASUREMENT_KEYS}}
+    empty_values = _empty_values()
+    context.user_data["body_params_values"] = empty_values
+    context.user_data["body_params_draft"] = {**empty_values}
+    context.user_data["body_params_dirty"] = False
 
     await _refresh_card(
         context,

--- a/bot/keyboards/body_params_menu.py
+++ b/bot/keyboards/body_params_menu.py
@@ -19,7 +19,7 @@ BODY_PARAM_BUTTONS: list[tuple[str, str]] = [
 ]
 
 
-def get_body_params_menu(has_data: bool = False) -> InlineKeyboardMarkup:
+def get_body_params_menu(has_data: bool = False, *, can_save: bool = False) -> InlineKeyboardMarkup:
     """Возвращает клавиатуру с параметрами тела."""
 
     keyboard: list[list[InlineKeyboardButton]] = []
@@ -29,6 +29,11 @@ def get_body_params_menu(has_data: bool = False) -> InlineKeyboardMarkup:
         for title, callback_data in BODY_PARAM_BUTTONS[i : i + 3]:
             row_buttons.append(InlineKeyboardButton(title, callback_data=callback_data))
         keyboard.append(row_buttons)
+
+    if can_save:
+        keyboard.append([
+            InlineKeyboardButton("💾 Сохранить замеры", callback_data="body_params_save")
+        ])
 
     if has_data:
         keyboard.append([

--- a/bot/main.py
+++ b/bot/main.py
@@ -59,6 +59,8 @@ from bot.handlers.body_params import (
     show_body_params,
     prompt_body_param,
     handle_body_param_input,
+    cancel_body_param_input,
+    save_body_params,
     delete_body_params,
 )
 from handlers.set_age import set_age
@@ -152,6 +154,7 @@ def main() -> None:
                 prompt_body_param,
                 pattern='^body_param_(date|neck|chest|waist|hips|thigh|calf|forearm|wrist)$'
             ),
+            CallbackQueryHandler(save_body_params, pattern='^body_params_save$'),
             CallbackQueryHandler(delete_body_params, pattern='^delete_body_params$'),
         ],
         states={
@@ -160,7 +163,10 @@ def main() -> None:
             SET_WEIGHT: [MessageHandler(filters.TEXT & ~filters.COMMAND, set_weight)],
             SET_HEIGHT: [MessageHandler(filters.TEXT & ~filters.COMMAND, set_height)],
             SET_GENDER: [MessageHandler(filters.TEXT & ~filters.COMMAND, set_gender)],
-            SET_BODY_PARAM: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_body_param_input)],
+            SET_BODY_PARAM: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, handle_body_param_input),
+                CommandHandler("cancel", cancel_body_param_input),
+            ],
             AI_CONSULTATION: [
                 MessageHandler(filters.TEXT & ~filters.COMMAND, handle_ai_message),
                 CallbackQueryHandler(end_ai_consultation, pattern='^end_ai_consultation$'),


### PR DESCRIPTION
## Summary
- maintain a body measurement draft in user_data with unsaved state tracking and render the card accordingly
- update inline keyboard to show a save button when the draft is ready and add a save handler that issues POST/PATCH requests
- register state-specific /cancel handling and ensure delete/reset logic clears the draft

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d1295d5c4c832090a6e92f10094445