### PR TITLE
Add draft state and save handler for body params

### DIFF
--- a/bot/handlers/body_params.py
+++ b/bot/handlers/body_params.py
@@ -17,7 +17,6 @@ from bot.api.gym_stat_client import (
     create_body_params as api_create_body_params,
     delete_body_params as api_delete_body_params,
     get_body_params as api_get_body_params,
-    update_body_params as api_update_body_params,
 )
 from bot.config.settings import SET_BODY_PARAM
 from bot.keyboards.body_params_menu import get_body_params_menu
@@ -53,7 +52,11 @@ MEASUREMENT_KEYS = [
     "wrist",
 ]
 
-CARD_ORDER = ["date", *MEASUREMENT_KEYS]
+
+def _blank_values() -> dict[str, Any]:
+    """Возвращает словарь с пустыми значениями параметров."""
+
+    return {"date": None, **{key: None for key in MEASUREMENT_KEYS}}
 
 
 def _normalize_entries(payload: Any) -> list[dict[str, Any]]:
@@ -213,9 +216,7 @@ def _build_card_text(values: dict[str, Any] | None, status: str | None = None) -
 def _store_entry(context: ContextTypes.DEFAULT_TYPE, entry: dict[str, Any] | None) -> dict[str, Any]:
     """Сохраняет текущие значения обмеров в контексте пользователя."""
 
-    values: dict[str, Any] = {"date": None}
-    for key in MEASUREMENT_KEYS:
-        values[key] = None
+    values = _blank_values()
 
     if entry:
         uuid = entry.get("uuid") or entry.get("id")
@@ -238,6 +239,8 @@ def _store_entry(context: ContextTypes.DEFAULT_TYPE, entry: dict[str, Any] | Non
         context.user_data.pop("body_params_uuid", None)
 
     context.user_data["body_params_values"] = values
+    context.user_data["body_params_draft"] = dict(values)
+    context.user_data["body_params_dirty"] = False
     return values
 
 
@@ -306,8 +309,10 @@ async def _load_and_store(context: ContextTypes.DEFAULT_TYPE, token: str) -> tup
         values = _store_entry(context, entry)
     else:
         context.user_data.pop("body_params_uuid", None)
-        context.user_data["body_params_values"] = {"date": None, **{key: None for key in MEASUREMENT_KEYS}}
-        values = context.user_data["body_params_values"]
+        values = _blank_values()
+        context.user_data["body_params_values"] = values
+        context.user_data["body_params_draft"] = dict(values)
+        context.user_data["body_params_dirty"] = False
     return values, error
 
 
@@ -323,20 +328,28 @@ async def _refresh_card(
     """Перерисовывает карточку с обмерами."""
 
     values: dict[str, Any] | None = None
-    has_data = False
     status_message = status
 
     if not skip_fetch and token:
         values, error = await _load_and_store(context, token)
         if error and not status_message:
             status_message = f"❌ {html.escape(error)}"
-        has_data = bool(context.user_data.get("body_params_uuid"))
-    else:
+    if values is None:
         values = context.user_data.get("body_params_values")
-        has_data = bool(context.user_data.get("body_params_uuid"))
+
+    dirty = context.user_data.get("body_params_dirty", False)
+    if dirty:
+        draft_values = context.user_data.get("body_params_draft")
+        if isinstance(draft_values, dict):
+            values = draft_values
+
+    has_data = bool(context.user_data.get("body_params_uuid"))
 
     text = _build_card_text(values, status=status_message)
-    keyboard = get_body_params_menu(has_data=has_data)
+    keyboard = get_body_params_menu(
+        has_data=has_data,
+        can_save=context.user_data.get("body_params_dirty", False),
+    )
 
     if message_id is not None:
         try:
@@ -367,7 +380,10 @@ async def _render_placeholder(
     """Отображает заглушку и сбрасывает сохранённые данные."""
 
     context.user_data.pop("body_params_uuid", None)
-    context.user_data["body_params_values"] = {"date": None, **{key: None for key in MEASUREMENT_KEYS}}
+    values = _blank_values()
+    context.user_data["body_params_values"] = values
+    context.user_data["body_params_draft"] = dict(values)
+    context.user_data["body_params_dirty"] = False
 
     message = getattr(query, "message", None)
     if not message:
@@ -430,7 +446,10 @@ async def show_body_params(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     await message.edit_text(
         _build_card_text(values, status=status),
         parse_mode="HTML",
-        reply_markup=get_body_params_menu(has_data=bool(context.user_data.get("body_params_uuid"))),
+        reply_markup=get_body_params_menu(
+            has_data=bool(context.user_data.get("body_params_uuid")),
+            can_save=context.user_data.get("body_params_dirty", False),
+        ),
     )
     context.user_data["body_params_message"] = (message.chat_id, message.message_id)
     return ConversationHandler.END
@@ -619,45 +638,19 @@ async def handle_body_param_input(update: Update, context: ContextTypes.DEFAULT_
             )
         payload_value = int(round(value)) if abs(value - round(value)) < 1e-4 else round(value, 1)
 
-    payload = {param_key: payload_value}
-    existing_values = context.user_data.get("body_params_values", {})
-    uuid = context.user_data.get("body_params_uuid")
+    draft = context.user_data.get("body_params_draft")
+    if not isinstance(draft, dict):
+        base_values = context.user_data.get("body_params_values") or _blank_values()
+        draft = dict(base_values)
 
-    try:
-        if uuid:
-            response = await api_update_body_params(token, uuid, payload)
-        else:
-            create_payload = {
-                field: existing_values.get(field)
-                for field in CARD_ORDER
-                if existing_values.get(field) not in (None, "")
-            }
-            create_payload.update(payload)
-            response = await api_create_body_params(token, create_payload)
-    except httpx.HTTPError as exc:  # noqa: BLE001
-        logger.error("Ошибка HTTP при сохранении обмеров: %s", exc)
-        return await _abort_with_error(
-            "❌ Не удалось отправить данные. Попробуйте позже.",
-            "❌ Не удалось сохранить значение. Попробуйте позже.",
-        )
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Неожиданная ошибка при сохранении обмеров: %s", exc)
-        return await _abort_with_error(
-            "❌ Произошла ошибка при сохранении параметров.",
-            "❌ Не удалось сохранить значение. Попробуйте позже.",
-        )
-
-    if response.status_code >= 400:
-        error_text = _extract_error_message(response) or "Не удалось сохранить параметр."
-        return await _abort_with_error(
-            f"⚠️ {error_text}",
-            f"❌ {html.escape(error_text)}",
-        )
+    draft[param_key] = payload_value
+    context.user_data["body_params_draft"] = draft
+    context.user_data["body_params_dirty"] = True
 
     status_message = (
-        "✅ Дата замеров обновлена."
+        "✅ Дата замеров обновлена. Нажмите «Сохранить замеры», чтобы отправить данные."
         if param_key == "date"
-        else f"✅ Значение «{FIELD_TITLES[param_key]}» сохранено."
+        else f"✅ Значение «{FIELD_TITLES[param_key]}» обновлено. Не забудьте нажать «Сохранить замеры»."
     )
 
     await _refresh_card(
@@ -666,12 +659,170 @@ async def handle_body_param_input(update: Update, context: ContextTypes.DEFAULT_
         message_id=card_message_id,
         token=token,
         status=status_message,
+        skip_fetch=True,
     )
 
     schedule_message_deletion(context, [user_message_id], chat_id, delay=5)
     context.user_data["conversation_active"] = False
     context.user_data.pop("pending_body_param", None)
     context.user_data.pop("current_state", None)
+    return ConversationHandler.END
+
+
+async def cancel_body_param_input(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Отменяет ввод параметра и возвращает карточку обмеров."""
+
+    message = update.message
+    if message is None:
+        return ConversationHandler.END
+
+    chat_id = message.chat_id
+    user_id = message.from_user.id
+
+    schedule_message_deletion(context, [message.message_id], chat_id, delay=5)
+
+    context.user_data.pop("pending_body_param", None)
+    context.user_data.pop("current_state", None)
+    context.user_data["conversation_active"] = False
+
+    message_info = context.user_data.get("body_params_message")
+    card_chat_id, card_message_id = (message_info or (chat_id, None))
+
+    token = await get_valid_access_token(user_id)
+    await _refresh_card(
+        context,
+        chat_id=card_chat_id,
+        message_id=card_message_id,
+        token=token,
+        status="ℹ️ Ввод отменён.",
+        skip_fetch=True,
+    )
+
+    return ConversationHandler.END
+
+
+async def save_body_params(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Сохраняет черновик обмеров через API Gym-Stat."""
+
+    query = update.callback_query
+    if not query:
+        logger.warning("save_body_params вызван без callback_query")
+        return ConversationHandler.END
+
+    await query.answer()
+    user_id = query.from_user.id
+
+    context.user_data.pop("pending_body_param", None)
+    context.user_data.pop("current_state", None)
+    context.user_data["conversation_active"] = False
+
+    message = query.message
+    message_info = context.user_data.get("body_params_message")
+    card_chat_id, card_message_id = (message_info or ((message.chat_id if message else user_id), None))
+
+    draft = context.user_data.get("body_params_draft")
+    dirty = context.user_data.get("body_params_dirty", False)
+
+    if not dirty or not isinstance(draft, dict):
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=None,
+            status="⚠️ Нет изменений для сохранения.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    mode = await get_user_mode(user_id)
+    if mode != "api":
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=None,
+            status="🌐 Сохранение доступно только после подключения Gym-Stat.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    token = await get_valid_access_token(user_id)
+    if not token:
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=None,
+            status="🔐 Войдите через /login, чтобы отправить замеры.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    payload: dict[str, Any] = {}
+
+    normalized_date = _normalize_date_value(draft.get("date")) if draft.get("date") else None
+    if normalized_date:
+        payload["date"] = normalized_date
+    else:
+        payload["date"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    for key in MEASUREMENT_KEYS:
+        value = draft.get(key)
+        if value not in (None, ""):
+            payload[key] = value
+
+    try:
+        response = await api_create_body_params(token, payload)
+    except httpx.HTTPError as exc:  # noqa: BLE001
+        logger.error("Ошибка HTTP при создании обмеров: %s", exc)
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=token,
+            status="❌ Не удалось сохранить замеры. Попробуйте позже.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Неожиданная ошибка при создании обмеров: %s", exc)
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=token,
+            status="❌ Не удалось сохранить замеры. Попробуйте позже.",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    if response.status_code >= 400:
+        error_text = _extract_error_message(response) or "Не удалось сохранить замеры."
+        await _refresh_card(
+            context,
+            chat_id=card_chat_id,
+            message_id=card_message_id,
+            token=token,
+            status=f"❌ {html.escape(error_text)}",
+            skip_fetch=True,
+        )
+        return ConversationHandler.END
+
+    _, load_error = await _load_and_store(context, token)
+    if load_error:
+        status_text = f"✅ Замеры сохранены, но не удалось обновить данные: {html.escape(load_error)}"
+    else:
+        status_text = "✅ Замеры сохранены и синхронизированы с Gym-Stat."
+
+    await _refresh_card(
+        context,
+        chat_id=card_chat_id,
+        message_id=card_message_id,
+        token=token,
+        status=status_text,
+        skip_fetch=True,
+    )
+
     return ConversationHandler.END
 
 
@@ -769,7 +920,10 @@ async def delete_body_params(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
     # После успешного удаления сбрасываем сохранённые значения
     context.user_data.pop("body_params_uuid", None)
-    context.user_data["body_params_values"] = {"date": None, **{key: None for key in MEASUREMENT_KEYS}}
+    values = _blank_values()
+    context.user_data["body_params_values"] = values
+    context.user_data["body_params_draft"] = dict(values)
+    context.user_data["body_params_dirty"] = False
 
     await _refresh_card(
         context,


### PR DESCRIPTION
## Summary
- keep a mutable draft of body measurements in user data and only show the save action while values are dirty
- rewrite the input handler to validate and stage changes, plus add cancel/save flows that call the Gym-Stat API when requested

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1460991208320a250f246368122c9