### PR TITLE
Исправить выбор группы упражнения при создании и редактировании

### DIFF
--- a/bot/handlers/exercises.py
+++ b/bot/handlers/exercises.py
@@ -58,6 +58,8 @@ _EXERCISE_PROMPT_KEY = "exercise_prompt"
 _EXERCISE_DRAFT_KEY = "exercise_draft"
 _EXERCISE_UUID_KEY = "exercise_uuid"
 _EXERCISE_CACHE_KEY = "exercises_cache"
+_EXERCISE_GROUP_CHOICES_KEY = "exercise_group_choices"
+_EXERCISE_GROUP_UPDATE_CHOICES_KEY = "exercise_group_update_choices"
 
 
 _DESCRIPTION_INTRO = (
@@ -166,7 +168,13 @@ def _reset_flow(context: ContextTypes.DEFAULT_TYPE) -> None:
 
 def _reset_exercise_flow(context: ContextTypes.DEFAULT_TYPE) -> None:
     """Удаляет временные данные, связанные с управлением упражнениями."""
-    for key in (_EXERCISE_PROMPT_KEY, _EXERCISE_DRAFT_KEY, _EXERCISE_UUID_KEY):
+    for key in (
+        _EXERCISE_PROMPT_KEY,
+        _EXERCISE_DRAFT_KEY,
+        _EXERCISE_UUID_KEY,
+        _EXERCISE_GROUP_CHOICES_KEY,
+        _EXERCISE_GROUP_UPDATE_CHOICES_KEY,
+    ):
         context.user_data.pop(key, None)
 
 
@@ -638,6 +646,12 @@ async def handle_exercise_description_input(
             context.user_data["conversation_active"] = False
             return ConversationHandler.END
 
+    context.user_data[_EXERCISE_GROUP_CHOICES_KEY] = {
+        str(index): group.get("uuid")
+        for index, group in enumerate(groups)
+        if isinstance(group, dict) and group.get("uuid")
+    }
+
     prompt = context.user_data.get(_EXERCISE_PROMPT_KEY)
     text = (
         "📂 <b>Выберите группу для упражнения</b>\n"
@@ -669,8 +683,13 @@ async def handle_exercise_group_selection(update: Update, context: ContextTypes.
     await query.answer()
     user_id = query.from_user.id
     data = query.data or ""
-    parts = data.split(":", 3)
-    group_uuid = parts[3] if len(parts) == 4 else ""
+    if data.startswith("exercise:select_group:create:"):
+        group_uuid = data.rsplit(":", 1)[-1]
+    else:
+        parts = data.split(":", 2)
+        choice_key = parts[2] if len(parts) >= 3 else ""
+        choices = context.user_data.get(_EXERCISE_GROUP_CHOICES_KEY, {}) or {}
+        group_uuid = choices.get(choice_key, "")
 
     draft = context.user_data.get(_EXERCISE_DRAFT_KEY)
     name = draft.get("name") if isinstance(draft, dict) else None
@@ -859,6 +878,11 @@ async def prompt_rename_exercise(update: Update, context: ContextTypes.DEFAULT_T
 
     context.user_data[_EXERCISE_UUID_KEY] = uuid
     context.user_data[_EXERCISE_PROMPT_KEY] = (query.message.chat_id, query.message.message_id)
+    context.user_data[_EXERCISE_GROUP_UPDATE_CHOICES_KEY] = {
+        str(index): group.get("uuid")
+        for index, group in enumerate(groups)
+        if isinstance(group, dict) and group.get("uuid")
+    }
 
     await query.message.edit_text(
         (
@@ -1129,6 +1153,11 @@ async def prompt_change_exercise_group(update: Update, context: ContextTypes.DEF
 
     context.user_data[_EXERCISE_UUID_KEY] = uuid
     context.user_data[_EXERCISE_PROMPT_KEY] = (query.message.chat_id, query.message.message_id)
+    context.user_data[_EXERCISE_GROUP_UPDATE_CHOICES_KEY] = {
+        str(index): group.get("uuid")
+        for index, group in enumerate(groups)
+        if isinstance(group, dict) and group.get("uuid")
+    }
 
     await query.message.edit_text(
         (
@@ -1150,9 +1179,16 @@ async def handle_exercise_group_update_selection(
     await query.answer()
     user_id = query.from_user.id
     data = query.data or ""
-    parts = data.split(":", 4)
-    exercise_uuid = parts[3] if len(parts) >= 4 else ""
-    group_uuid = parts[4] if len(parts) >= 5 else ""
+    if data.startswith("exercise:select_group:update:"):
+        parts = data.split(":", 4)
+        exercise_uuid = parts[3] if len(parts) >= 4 else ""
+        group_uuid = parts[4] if len(parts) >= 5 else ""
+    else:
+        parts = data.split(":", 2)
+        choice_key = parts[2] if len(parts) >= 3 else ""
+        exercise_uuid = context.user_data.get(_EXERCISE_UUID_KEY, "")
+        update_choices = context.user_data.get(_EXERCISE_GROUP_UPDATE_CHOICES_KEY, {}) or {}
+        group_uuid = update_choices.get(choice_key, "")
 
     if not exercise_uuid or not group_uuid:
         await query.message.edit_text(

--- a/bot/keyboards/exercises_menu.py
+++ b/bot/keyboards/exercises_menu.py
@@ -109,7 +109,7 @@ def get_exercise_group_delete_keyboard(uuid: str) -> InlineKeyboardMarkup:
 def build_exercise_group_selection_keyboard(groups: Iterable[dict]) -> InlineKeyboardMarkup:
     """Клавиатура выбора группы при создании упражнения."""
     keyboard: list[list[InlineKeyboardButton]] = []
-    for group in groups:
+    for index, group in enumerate(groups):
         if not isinstance(group, dict):
             continue
         uuid = group.get("uuid")
@@ -119,7 +119,7 @@ def build_exercise_group_selection_keyboard(groups: Iterable[dict]) -> InlineKey
         keyboard.append(
             [
                 InlineKeyboardButton(
-                    _shorten(str(name)), callback_data=f"exercise:select_group:create:{uuid}"
+                    _shorten(str(name)), callback_data=f"ex:sgc:{index}"
                 )
             ]
         )
@@ -132,7 +132,7 @@ def build_exercise_group_update_keyboard(
 ) -> InlineKeyboardMarkup:
     """Клавиатура выбора группы при изменении упражнения."""
     keyboard: list[list[InlineKeyboardButton]] = []
-    for group in groups:
+    for index, group in enumerate(groups):
         if not isinstance(group, dict):
             continue
         group_uuid = group.get("uuid")
@@ -142,8 +142,7 @@ def build_exercise_group_update_keyboard(
         keyboard.append(
             [
                 InlineKeyboardButton(
-                    _shorten(str(name)),
-                    callback_data=f"exercise:select_group:update:{exercise_uuid}:{group_uuid}",
+                    _shorten(str(name)), callback_data=f"ex:sgu:{index}"
                 )
             ]
         )

--- a/bot/main.py
+++ b/bot/main.py
@@ -187,7 +187,7 @@ def main() -> None:
             ),
             CallbackQueryHandler(
                 handle_exercise_group_selection,
-                pattern='^exercise:select_group:create:[^:]+$'
+                pattern='^(exercise:select_group:create:[^:]+|ex:sgc:[0-9]+)$'
             ),
             CallbackQueryHandler(
                 handle_exercise_creation_cancel,
@@ -207,7 +207,7 @@ def main() -> None:
             ),
             CallbackQueryHandler(
                 handle_exercise_group_update_selection,
-                pattern='^exercise:select_group:update:[^:]+:[^:]+$'
+                pattern='^(exercise:select_group:update:[^:]+:[^:]+|ex:sgu:[0-9]+)$'
             ),
             CallbackQueryHandler(
                 ask_delete_exercise,


### PR DESCRIPTION
## Summary
- заменить длинные callback_data на короткие индексы при выборе группы упражнения
- сохранять сопоставление индексов и UUID групп в user_data и обрабатывать его в хендлерах
- обновить шаблоны обработчиков и учесть обратную совместимость с уже отправленными сообщениями

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d440f173f88320b803bddea4e6957f