### PR TITLE
Add workouts management flow

### DIFF
--- a/bot/api/gym_stat_client.py
+++ b/bot/api/gym_stat_client.py
@@ -82,12 +82,39 @@ async def update_profile(token: str, payload: Dict[str, Any]) -> httpx.Response:
     return await _request("PATCH", "/api/users/me", token=token, json=payload)
 
 
-async def get_trainings(
-    token: str, params: Optional[Dict[str, Any]] = None
+async def get_workouts(
+    token: str,
+    params: Optional[Dict[str, Any]] = None,
 ) -> httpx.Response:
     """Получение списка тренировок пользователя."""
-    # Список тренировок возвращается по маршруту ``/api/trainings``.
-    return await _request("GET", "/api/trainings", token=token, params=params)
+    return await _request("GET", "/api/workouts", token=token, params=params)
+
+
+async def get_workout(token: str, uuid: str) -> httpx.Response:
+    """Получение данных конкретной тренировки."""
+    endpoint = f"/api/workouts/{uuid}"
+    return await _request("GET", endpoint, token=token)
+
+
+async def create_workout(token: str, payload: Dict[str, Any]) -> httpx.Response:
+    """Создание новой тренировки."""
+    return await _request("POST", "/api/workouts", token=token, json=payload)
+
+
+async def update_workout(
+    token: str,
+    uuid: str,
+    payload: Dict[str, Any],
+) -> httpx.Response:
+    """Обновление тренировки."""
+    endpoint = f"/api/workouts/{uuid}"
+    return await _request("PATCH", endpoint, token=token, json=payload)
+
+
+async def delete_workout(token: str, uuid: str) -> httpx.Response:
+    """Удаление тренировки."""
+    endpoint = f"/api/workouts/{uuid}"
+    return await _request("DELETE", endpoint, token=token)
 
 
 async def get_weight_data(

--- a/bot/config/settings.py
+++ b/bot/config/settings.py
@@ -80,7 +80,8 @@ str: Путь к файлу базы данных, используемой бо
     EXERCISE_SET_DESCRIPTION,
     EXERCISE_RENAME,
     EXERCISE_UPDATE_DESCRIPTION,
-) = range(15)
+    WORKOUT_CREATION,
+) = range(16)
 """
 Константы состояний ConversationHandler:
 - SET_NAME, SET_AGE, SET_WEIGHT, SET_HEIGHT, SET_GENDER — ввод персональных данных;

--- a/bot/handlers/workouts.py
+++ b/bot/handlers/workouts.py
@@ -1,0 +1,642 @@
+"""Handlers responsible for managing workouts via Gym-Stat API."""
+from __future__ import annotations
+
+from datetime import datetime, time
+from typing import Any, Dict, Iterable, Optional
+
+from telegram import Update
+from telegram.ext import ContextTypes, ConversationHandler
+
+from bot.api.gym_stat_client import (
+    create_workout as api_create_workout,
+    get_exercises as api_get_exercises,
+    get_workout as api_get_workout,
+    get_workouts as api_get_workouts,
+)
+from bot.config.settings import WORKOUT_CREATION
+from bot.keyboards.workouts_menu import (
+    build_exercise_selection_keyboard,
+    build_workouts_keyboard,
+    get_workout_details_keyboard,
+)
+from bot.utils.api_session import get_valid_access_token
+from bot.utils.db_utils import get_user_mode
+from bot.utils.logger import setup_logging
+from bot.utils.message_deletion import schedule_message_deletion
+
+
+logger = setup_logging()
+
+_WORKOUT_STAGE_KEY = "workout_stage"
+_WORKOUT_DRAFT_KEY = "workout_draft"
+_WORKOUT_MESSAGE_IDS_KEY = "workout_prompt_ids"
+_WORKOUT_EXERCISES_KEY = "workout_exercise_choices"
+_DATE_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+async def show_workouts_menu(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
+    """Displays the workouts menu with buttons to view or create workouts."""
+    query = update.callback_query
+    await query.answer()
+    user_id = query.from_user.id
+
+    mode = await get_user_mode(user_id)
+    if mode != "api":
+        await query.message.edit_text(
+            (
+                "🏋️ <b>Тренировки доступны только в режиме Gym-Stat</b>\n"
+                "Переключитесь на интеграцию через кнопку ниже и выполните вход,"
+                " чтобы управлять своими тренировками и синхронизировать их с сайтом."
+            ),
+            parse_mode="HTML",
+            reply_markup=build_workouts_keyboard([], include_create=False),
+        )
+        context.user_data["conversation_active"] = False
+        return ConversationHandler.END
+
+    token = await get_valid_access_token(user_id)
+    if not token:
+        await query.message.edit_text(
+            (
+                "🔐 <b>Нужна авторизация</b>\n"
+                "Чтобы просматривать и создавать тренировки, войдите в аккаунт Gym-Stat"
+                " через команду /login или кнопку «Войти» в меню настроек."
+            ),
+            parse_mode="HTML",
+            reply_markup=build_workouts_keyboard([], include_create=False),
+        )
+        context.user_data["conversation_active"] = False
+        return ConversationHandler.END
+
+    workouts = await _fetch_workouts(token)
+    if workouts is None:
+        await query.message.edit_text(
+            (
+                "❌ <b>Не удалось получить список тренировок</b>\n"
+                "Попробуйте повторить попытку чуть позже."
+            ),
+            parse_mode="HTML",
+            reply_markup=build_workouts_keyboard([], include_create=True),
+        )
+        context.user_data["conversation_active"] = False
+        return ConversationHandler.END
+
+    description = (
+        "🗂️ <b>Ваши тренировки</b>\n"
+        "Выберите тренировку, чтобы посмотреть подробности, либо создайте новую."
+    )
+    await query.message.edit_text(
+        description,
+        parse_mode="HTML",
+        reply_markup=build_workouts_keyboard(workouts),
+    )
+    context.user_data["conversation_active"] = False
+    return ConversationHandler.END
+
+
+async def show_workout_details(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
+    """Shows details for a particular workout."""
+    query = update.callback_query
+    await query.answer()
+    user_id = query.from_user.id
+    uuid = query.data.split(":", maxsplit=2)[-1]
+
+    mode = await get_user_mode(user_id)
+    if mode != "api":
+        await query.message.edit_text(
+            (
+                "ℹ️ Просмотр тренировок доступен только при активной интеграции"
+                " с Gym-Stat."
+            ),
+            parse_mode="HTML",
+            reply_markup=build_workouts_keyboard([], include_create=False),
+        )
+        context.user_data["conversation_active"] = False
+        return ConversationHandler.END
+
+    token = await get_valid_access_token(user_id)
+    if not token:
+        await query.message.edit_text(
+            (
+                "🔐 <b>Нужна авторизация</b>\n"
+                "Чтобы открыть тренировку, войдите в Gym-Stat через /login."
+            ),
+            parse_mode="HTML",
+            reply_markup=build_workouts_keyboard([], include_create=False),
+        )
+        context.user_data["conversation_active"] = False
+        return ConversationHandler.END
+
+    workout = await _fetch_workout(token, uuid)
+    if workout is None:
+        await query.message.edit_text(
+            (
+                "❌ <b>Не удалось получить данные тренировки</b>\n"
+                "Возможно, запись была удалена или временно недоступна."
+            ),
+            parse_mode="HTML",
+            reply_markup=build_workouts_keyboard([], include_create=True),
+        )
+        context.user_data["conversation_active"] = False
+        return ConversationHandler.END
+
+    await query.message.edit_text(
+        _format_workout_details(workout),
+        parse_mode="HTML",
+        reply_markup=get_workout_details_keyboard(),
+    )
+    context.user_data["conversation_active"] = False
+    return ConversationHandler.END
+
+
+async def start_create_workout(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
+    """Begins the guided flow for creating a workout."""
+    query = update.callback_query
+    await query.answer()
+    user_id = query.from_user.id
+
+    mode = await get_user_mode(user_id)
+    if mode != "api":
+        await query.message.edit_text(
+            (
+                "🏋️ Создание тренировки доступно после переключения на режим"
+                " Gym-Stat."
+            ),
+            parse_mode="HTML",
+            reply_markup=build_workouts_keyboard([], include_create=False),
+        )
+        context.user_data["conversation_active"] = False
+        return ConversationHandler.END
+
+    token = await get_valid_access_token(user_id)
+    if not token:
+        await query.message.edit_text(
+            (
+                "🔐 <b>Сначала выполните вход</b>\n"
+                "Команда /login или кнопка «Войти» в настройках помогут"
+                " авторизоваться в Gym-Stat."
+            ),
+            parse_mode="HTML",
+            reply_markup=build_workouts_keyboard([], include_create=False),
+        )
+        context.user_data["conversation_active"] = False
+        return ConversationHandler.END
+
+    context.user_data[_WORKOUT_STAGE_KEY] = "name"
+    context.user_data[_WORKOUT_DRAFT_KEY] = {}
+    context.user_data[_WORKOUT_MESSAGE_IDS_KEY] = []
+
+    message = await query.message.edit_text(
+        (
+            "📝 <b>Введите название тренировки</b>\n"
+            "Например: <code>Грудь и плечи</code>."
+        ),
+        parse_mode="HTML",
+    )
+    context.user_data[_WORKOUT_MESSAGE_IDS_KEY].append(message.message_id)
+    context.user_data["conversation_active"] = True
+    context.user_data["workout_token"] = token
+    return WORKOUT_CREATION
+
+
+async def handle_workout_creation_input(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
+    """Processes user input for each workout creation step."""
+    stage = context.user_data.get(_WORKOUT_STAGE_KEY)
+    draft: Dict[str, Any] = context.user_data.get(_WORKOUT_DRAFT_KEY, {})
+    token: Optional[str] = context.user_data.get("workout_token")
+
+    if stage is None or draft is None or token is None:
+        await update.message.reply_text(
+            "⚠️ Возникла ошибка. Попробуйте начать создание тренировки заново.",
+        )
+        context.user_data["conversation_active"] = False
+        _reset_workout_flow(context)
+        return ConversationHandler.END
+
+    text = update.message.text.strip()
+    chat_id = update.message.chat_id
+
+    if stage == "name":
+        draft["name"] = text
+        context.user_data[_WORKOUT_STAGE_KEY] = "description"
+        message = await update.message.reply_text(
+            (
+                "📝 <b>Добавьте описание тренировки</b>\n"
+                "Например: <code>Силовая работа с акцентом на базовые упражнения</code>."
+            ),
+            parse_mode="HTML",
+        )
+        _remember_prompt(context, message.message_id, chat_id)
+        return WORKOUT_CREATION
+
+    if stage == "description":
+        draft["description"] = text
+        context.user_data[_WORKOUT_STAGE_KEY] = "date"
+        message = await update.message.reply_text(
+            (
+                "📅 <b>Укажите дату тренировки</b> в формате"
+                " <code>дд-мм-гггг</code>."
+            ),
+            parse_mode="HTML",
+        )
+        _remember_prompt(context, message.message_id, chat_id)
+        return WORKOUT_CREATION
+
+    if stage == "date":
+        parsed_date = _parse_user_date(text)
+        if not parsed_date:
+            message = await update.message.reply_text(
+                "⚠️ Неверный формат даты. Используйте <code>дд-мм-гггг</code>.",
+                parse_mode="HTML",
+            )
+            _remember_prompt(context, message.message_id, chat_id)
+            return WORKOUT_CREATION
+        draft["date"] = parsed_date
+        context.user_data[_WORKOUT_STAGE_KEY] = "duration"
+        message = await update.message.reply_text(
+            "⏱️ <b>Укажите длительность тренировки</b> в минутах.",
+            parse_mode="HTML",
+        )
+        _remember_prompt(context, message.message_id, chat_id)
+        return WORKOUT_CREATION
+
+    if stage == "duration":
+        if not text.isdigit() or int(text) <= 0:
+            message = await update.message.reply_text(
+                "⚠️ Введите целое число минут больше нуля.",
+            )
+            _remember_prompt(context, message.message_id, chat_id)
+            return WORKOUT_CREATION
+        draft["duration"] = int(text)
+        context.user_data[_WORKOUT_STAGE_KEY] = "calories"
+        message = await update.message.reply_text(
+            "🔥 <b>Укажите потраченные калории</b> (целое число).",
+            parse_mode="HTML",
+        )
+        _remember_prompt(context, message.message_id, chat_id)
+        return WORKOUT_CREATION
+
+    if stage == "calories":
+        if not text.isdigit() or int(text) < 0:
+            message = await update.message.reply_text(
+                "⚠️ Калории вводятся целым числом не меньше нуля.",
+            )
+            _remember_prompt(context, message.message_id, chat_id)
+            return WORKOUT_CREATION
+        draft["calories"] = int(text)
+
+        exercises = await _fetch_exercises(token)
+        if exercises is None:
+            await update.message.reply_text(
+                "❌ Не удалось получить список упражнений. Попробуйте позже.",
+            )
+            context.user_data["conversation_active"] = False
+            _reset_workout_flow(context)
+            return ConversationHandler.END
+        if not exercises:
+            await update.message.reply_text(
+                (
+                    "📋 Сначала создайте хотя бы одно упражнение в разделе"
+                    " «Упражнения», затем повторите создание тренировки."
+                )
+            )
+            context.user_data["conversation_active"] = False
+            _reset_workout_flow(context)
+            return ConversationHandler.END
+
+        context.user_data[_WORKOUT_STAGE_KEY] = "exercise"
+        context.user_data[_WORKOUT_EXERCISES_KEY] = {
+            exercise.get("uuid"): exercise for exercise in exercises if exercise.get("uuid")
+        }
+        keyboard = build_exercise_selection_keyboard(exercises)
+        message = await update.message.reply_text(
+            (
+                "💪 <b>Выберите упражнение для тренировки</b>."
+                " После выбора бот попросит указать вес, повторы и интенсивность."
+            ),
+            parse_mode="HTML",
+            reply_markup=keyboard,
+        )
+        _remember_prompt(context, message.message_id, chat_id)
+        return WORKOUT_CREATION
+
+    if stage == "exercise":
+        message = await update.message.reply_text(
+            "ℹ️ Выберите упражнение, используя кнопки под предыдущим сообщением.",
+        )
+        _remember_prompt(context, message.message_id, chat_id)
+        return WORKOUT_CREATION
+
+    if stage == "weight":
+        weight = _parse_number(text)
+        if weight is None or weight <= 0:
+            message = await update.message.reply_text(
+                "⚠️ Вес указывается положительным числом. Пример: 60 или 60.5",
+            )
+            _remember_prompt(context, message.message_id, chat_id)
+            return WORKOUT_CREATION
+        counts = draft.setdefault("counts", {})
+        counts["weight"] = weight
+        context.user_data[_WORKOUT_STAGE_KEY] = "reps"
+        message = await update.message.reply_text(
+            "🔢 Укажите количество повторов для подхода (целое число).",
+        )
+        _remember_prompt(context, message.message_id, chat_id)
+        return WORKOUT_CREATION
+
+    if stage == "reps":
+        if not text.isdigit() or int(text) <= 0:
+            message = await update.message.reply_text(
+                "⚠️ Повторы вводятся целым числом больше нуля.",
+            )
+            _remember_prompt(context, message.message_id, chat_id)
+            return WORKOUT_CREATION
+        counts = draft.setdefault("counts", {})
+        counts["reps"] = int(text)
+        context.user_data[_WORKOUT_STAGE_KEY] = "intensity"
+        message = await update.message.reply_text(
+            (
+                "💥 Укажите степень интенсивности (например: <code>no-failure</code>,"
+                " <code>muscle-failure</code>, <code>technical-failure</code>)."
+                " Чтобы пропустить, отправьте <code>-</code>."
+            ),
+            parse_mode="HTML",
+        )
+        _remember_prompt(context, message.message_id, chat_id)
+        return WORKOUT_CREATION
+
+    if stage == "intensity":
+        counts = draft.setdefault("counts", {})
+        intensity = text.strip()
+        if intensity and intensity != "-":
+            counts["type"] = intensity.replace(" ", "-").lower()
+        payload = _prepare_payload(draft)
+        if payload is None:
+            await update.message.reply_text(
+                "⚠️ Не удалось подготовить данные тренировки. Попробуйте снова.",
+            )
+            context.user_data["conversation_active"] = False
+            _reset_workout_flow(context)
+            return ConversationHandler.END
+
+        response = await api_create_workout(token, payload)
+        if response.status_code not in (200, 201):
+            logger.warning(
+                "Ошибка создания тренировки: %s", response.text
+            )
+            await update.message.reply_text(
+                "❌ Не удалось создать тренировку. Попробуйте повторить попытку позже.",
+            )
+            context.user_data["conversation_active"] = False
+            _reset_workout_flow(context)
+            return ConversationHandler.END
+
+        workouts = await _fetch_workouts(token) or []
+        await update.message.reply_text(
+            "✅ Тренировка успешно сохранена в Gym-Stat!",
+            reply_markup=build_workouts_keyboard(workouts),
+            parse_mode="HTML",
+        )
+        context.user_data["conversation_active"] = False
+        _reset_workout_flow(context)
+        return ConversationHandler.END
+
+    await update.message.reply_text(
+        "⚠️ Неизвестный шаг. Попробуйте начать заново.",
+    )
+    context.user_data["conversation_active"] = False
+    _reset_workout_flow(context)
+    return ConversationHandler.END
+
+
+async def handle_workout_exercise_selection(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
+    """Handles exercise selection within the workout creation flow."""
+    query = update.callback_query
+    await query.answer()
+    exercise_uuid = query.data.split(":", maxsplit=2)[-1]
+
+    stage = context.user_data.get(_WORKOUT_STAGE_KEY)
+    if stage != "exercise":
+        await query.message.edit_text(
+            "⚠️ Сейчас выбор упражнения недоступен. Начните создание тренировки заново.",
+        )
+        context.user_data["conversation_active"] = False
+        _reset_workout_flow(context)
+        return ConversationHandler.END
+
+    draft: Dict[str, Any] = context.user_data.get(_WORKOUT_DRAFT_KEY, {})
+    exercise_choices: Dict[str, Dict[str, Any]] = context.user_data.get(
+        _WORKOUT_EXERCISES_KEY, {}
+    )
+    if exercise_uuid not in exercise_choices:
+        await query.message.edit_text(
+            "⚠️ Выбранное упражнение недоступно. Попробуйте выбрать другое.",
+            reply_markup=build_exercise_selection_keyboard(
+                exercise_choices.values()
+            ),
+        )
+        return WORKOUT_CREATION
+
+    draft["exerciseId"] = exercise_uuid
+    context.user_data[_WORKOUT_STAGE_KEY] = "weight"
+
+    await query.message.edit_text(
+        (
+            "⚖️ Введите вес для подхода. Можно указать дробное значение через"
+            " точку."
+        )
+    )
+    return WORKOUT_CREATION
+
+
+async def _fetch_workouts(token: str) -> Optional[list[dict[str, Any]]]:
+    response = await api_get_workouts(token)
+    if response.status_code != 200:
+        logger.warning("Не удалось получить тренировки: %s", response.text)
+        return None
+    try:
+        data = response.json()
+    except ValueError:
+        logger.error("Некорректный JSON списка тренировок")
+        return None
+    if isinstance(data, list):
+        return data
+    logger.error("Неожиданный формат списка тренировок: %s", data)
+    return None
+
+
+async def _fetch_workout(token: str, uuid: str) -> Optional[dict[str, Any]]:
+    response = await api_get_workout(token, uuid)
+    if response.status_code != 200:
+        logger.warning("Не удалось получить тренировку %s: %s", uuid, response.text)
+        return None
+    try:
+        data = response.json()
+    except ValueError:
+        logger.error("Некорректный JSON тренировки %s", uuid)
+        return None
+    if isinstance(data, dict):
+        return data
+    logger.error("Неожиданный формат данных тренировки %s: %s", uuid, data)
+    return None
+
+
+async def _fetch_exercises(token: str) -> Optional[list[dict[str, Any]]]:
+    response = await api_get_exercises(token)
+    if response.status_code != 200:
+        logger.warning("Не удалось получить упражнения: %s", response.text)
+        return None
+    try:
+        data = response.json()
+    except ValueError:
+        logger.error("Некорректный JSON упражнений")
+        return None
+    if isinstance(data, list):
+        return data
+    logger.error("Неожиданный формат списка упражнений: %s", data)
+    return None
+
+
+def _format_workout_details(workout: dict[str, Any]) -> str:
+    name = workout.get("name") or "Без названия"
+    description = workout.get("description") or "—"
+    date_value = workout.get("date")
+    duration = workout.get("duration")
+    calories = workout.get("calories")
+
+    parts = [
+        f"🏋️ <b>{name}</b>",
+        f"Описание: {description}",
+    ]
+    if date_value:
+        parts.append(f"Дата: {_format_date(date_value)}")
+    if duration:
+        parts.append(f"Длительность: {duration} мин")
+    if calories is not None:
+        parts.append(f"Калории: {calories}")
+
+    sets = workout.get("sets") or []
+    if sets:
+        parts.append("\n<b>Подходы:</b>")
+        for idx, workout_set in enumerate(sets, start=1):
+            exercise_id = workout_set.get("exerciseId") or "—"
+            counts = workout_set.get("counts") or []
+            parts.append(f"{idx}. Упражнение: {exercise_id}")
+            for count_idx, count in enumerate(counts, start=1):
+                reps = count.get("reps")
+                weight = count.get("weight")
+                intensity = count.get("type")
+                line = f"   • Подход {count_idx}: {reps} повторов, вес {weight}"
+                if intensity:
+                    line += f", интенсивность: {intensity}"
+                parts.append(line)
+    else:
+        parts.append("\nПодходы ещё не добавлены.")
+
+    return "\n".join(parts)
+
+
+def _parse_user_date(value: str) -> Optional[str]:
+    try:
+        parsed = datetime.strptime(value, "%d-%m-%Y")
+    except ValueError:
+        return None
+    result = datetime.combine(parsed.date(), time.min)
+    return result.isoformat(sep=" ")
+
+
+def _parse_number(value: str) -> Optional[float]:
+    normalized = value.replace(",", ".")
+    try:
+        return float(normalized)
+    except ValueError:
+        return None
+
+
+def _format_date(value: str) -> str:
+    clean = value.strip()
+    if clean.endswith("Z"):
+        clean = clean[:-1] + "+00:00"
+    for fmt in _DATE_FORMATS:
+        try:
+            parsed = datetime.strptime(clean, fmt)
+        except ValueError:
+            continue
+        return parsed.strftime("%d.%m.%Y")
+    return value
+
+
+def _prepare_payload(draft: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    name = draft.get("name")
+    description = draft.get("description")
+    date_value = draft.get("date")
+    duration = draft.get("duration")
+    calories = draft.get("calories")
+    exercise_id = draft.get("exerciseId")
+    counts: Dict[str, Any] = draft.get("counts", {})
+
+    if not all([name, description, date_value, duration is not None, calories is not None, exercise_id]):
+        return None
+    reps = counts.get("reps")
+    weight = counts.get("weight")
+    if reps is None or weight is None:
+        return None
+
+    if isinstance(weight, float) and weight.is_integer():
+        weight = int(weight)
+
+    count_entry: Dict[str, Any] = {
+        "reps": reps,
+        "weight": weight,
+    }
+    if counts.get("type"):
+        count_entry["type"] = counts["type"]
+
+    payload = {
+        "name": name,
+        "description": description,
+        "date": date_value,
+        "duration": duration,
+        "calories": calories,
+        "sets": [
+            {
+                "exerciseId": exercise_id,
+                "counts": [count_entry],
+            }
+        ],
+    }
+    return payload
+
+
+def _reset_workout_flow(context: ContextTypes.DEFAULT_TYPE) -> None:
+    context.user_data.pop(_WORKOUT_STAGE_KEY, None)
+    context.user_data.pop(_WORKOUT_DRAFT_KEY, None)
+    context.user_data.pop(_WORKOUT_MESSAGE_IDS_KEY, None)
+    context.user_data.pop(_WORKOUT_EXERCISES_KEY, None)
+    context.user_data.pop("workout_token", None)
+
+
+def _remember_prompt(
+    context: ContextTypes.DEFAULT_TYPE,
+    message_id: int,
+    chat_id: int,
+    *,
+    delay: int = 300,
+) -> None:
+    context.user_data.setdefault(_WORKOUT_MESSAGE_IDS_KEY, []).append(message_id)
+    schedule_message_deletion(context, [message_id], chat_id, delay=delay)

--- a/bot/keyboards/main_menu.py
+++ b/bot/keyboards/main_menu.py
@@ -33,17 +33,15 @@ def get_main_menu(mode: str = "local"):
     keyboard = [
         [
             InlineKeyboardButton("🏋️‍♂️ Начать тренировку", callback_data='start_training'),
-            InlineKeyboardButton("🗂️ Мои упражнения", callback_data='my_trainings')
+            InlineKeyboardButton("🗂️ Тренировки", callback_data='workouts')
         ],
         [
-            InlineKeyboardButton("🔄 Сменить режим", callback_data='switch_mode'),
-            InlineKeyboardButton("🤖 AI-консультант", callback_data='my_ai_assistant')
+            InlineKeyboardButton("📋 Упражнения", callback_data='exercises_menu'),
+            InlineKeyboardButton("🔄 Сменить режим", callback_data='switch_mode')
         ],
-
         [
-            InlineKeyboardButton(
-                "⚙️ Настройки", callback_data='settings'
-            )
+            InlineKeyboardButton("🤖 AI-консультант", callback_data='my_ai_assistant'),
+            InlineKeyboardButton("⚙️ Настройки", callback_data='settings')
         ]
     ]
     if mode == "api":

--- a/bot/keyboards/workouts_menu.py
+++ b/bot/keyboards/workouts_menu.py
@@ -1,0 +1,95 @@
+"""Inline keyboards for managing workouts."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Sequence
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+_DATE_FORMATS: Sequence[str] = (
+    "%Y-%m-%dT%H:%M:%S.%f%z",
+    "%Y-%m-%dT%H:%M:%S%z",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def _format_workout_label(name: str | None, date_value: str | None) -> str:
+    """Builds a human friendly label for a workout button."""
+    display_name = name or "Без названия"
+    if not date_value:
+        return display_name
+
+    clean = date_value.strip()
+    if clean.endswith("Z"):
+        clean = clean[:-1] + "+00:00"
+
+    for fmt in _DATE_FORMATS:
+        try:
+            parsed = datetime.strptime(clean, fmt)
+        except ValueError:
+            continue
+        formatted = parsed.strftime("%d.%m.%Y")
+        return f"{formatted} — {display_name}"
+
+    return display_name
+
+
+def build_workouts_keyboard(
+    workouts: Iterable[dict],
+    *,
+    include_create: bool = True,
+    include_exercises: bool = True,
+) -> InlineKeyboardMarkup:
+    """Constructs a keyboard for the workouts list."""
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for workout in workouts:
+        uuid = workout.get("uuid")
+        if not uuid:
+            continue
+        label = _format_workout_label(workout.get("name"), workout.get("date"))
+        if len(label) > 64:
+            label = label[:63] + "…"
+        keyboard.append([
+            InlineKeyboardButton(label, callback_data=f"workout:view:{uuid}"),
+        ])
+
+    if include_create:
+        keyboard.append([
+            InlineKeyboardButton("➕ Создать тренировку", callback_data="workout:create"),
+        ])
+
+    if include_exercises:
+        keyboard.append([
+            InlineKeyboardButton("📋 Упражнения", callback_data="exercises_menu"),
+        ])
+
+    keyboard.append([
+        InlineKeyboardButton("🔙 Назад", callback_data="main_menu"),
+    ])
+    return InlineKeyboardMarkup(keyboard)
+
+
+def get_workout_details_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard shown on the workout details screen."""
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton("🔙 К тренировкам", callback_data="workouts")]]
+    )
+
+
+def build_exercise_selection_keyboard(exercises: Iterable[dict]) -> InlineKeyboardMarkup:
+    """Keyboard that allows choosing an exercise for a workout set."""
+    keyboard: list[list[InlineKeyboardButton]] = []
+    for exercise in exercises:
+        uuid = exercise.get("uuid")
+        if not uuid:
+            continue
+        label = exercise.get("name") or "Без названия"
+        keyboard.append([
+            InlineKeyboardButton(label, callback_data=f"workout:select_exercise:{uuid}"),
+        ])
+
+    keyboard.append([
+        InlineKeyboardButton("🔙 Назад", callback_data="workouts"),
+    ])
+    return InlineKeyboardMarkup(keyboard)

--- a/bot/main.py
+++ b/bot/main.py
@@ -91,6 +91,13 @@ from bot.handlers.body_params import (
     save_body_params,
     delete_body_params,
 )
+from bot.handlers.workouts import (
+    handle_workout_creation_input,
+    handle_workout_exercise_selection,
+    show_workout_details,
+    show_workouts_menu,
+    start_create_workout,
+)
 from handlers.set_age import set_age
 from handlers.set_weight import set_weight
 from handlers.set_height import set_height
@@ -111,6 +118,7 @@ from bot.config.settings import (
     EXERCISE_SET_DESCRIPTION,
     EXERCISE_RENAME,
     EXERCISE_UPDATE_DESCRIPTION,
+    WORKOUT_CREATION,
 )
 from bot.ai_assistant.ai_handler import (
     choose_ai_model,
@@ -173,8 +181,20 @@ def main() -> None:
             CallbackQueryHandler(show_profile, pattern='^show_profile$'),
             CallbackQueryHandler(start_training, pattern='^start_training$'),
             CallbackQueryHandler(
+                show_workouts_menu,
+                pattern='^workouts$'
+            ),
+            CallbackQueryHandler(
                 show_exercises_menu,
-                pattern='^(my_trainings|exercises_menu)$'
+                pattern='^exercises_menu$'
+            ),
+            CallbackQueryHandler(
+                show_workout_details,
+                pattern='^workout:view:[^:]+$'
+            ),
+            CallbackQueryHandler(
+                start_create_workout,
+                pattern='^workout:create$'
             ),
             CallbackQueryHandler(show_exercises, pattern='^exercise_list$'),
             CallbackQueryHandler(
@@ -309,6 +329,16 @@ def main() -> None:
                     filters.TEXT & ~filters.COMMAND,
                     handle_exercise_description_update
                 )
+            ],
+            WORKOUT_CREATION: [
+                MessageHandler(
+                    filters.TEXT & ~filters.COMMAND,
+                    handle_workout_creation_input,
+                ),
+                CallbackQueryHandler(
+                    handle_workout_exercise_selection,
+                    pattern='^workout:select_exercise:[^:]+$'
+                ),
             ],
             AI_CONSULTATION: [
                 MessageHandler(filters.TEXT & ~filters.COMMAND, handle_ai_message),


### PR DESCRIPTION
## Summary
- add Gym-Stat workout client helpers and keyboards for listing and creation flows
- implement conversation handlers that guide users through creating workouts with sets via the API
- refresh the main menu and conversation registration to expose workouts alongside existing exercise tools

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d45885e03c8320a5fba197f0223bac