### PR TITLE
Add Gym-Stat statistics menu

### DIFF
--- a/bot/commands/settings_command.py
+++ b/bot/commands/settings_command.py
@@ -33,6 +33,8 @@ async def settings(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if mode == 'api':
             api_hint = (
                 "• «📏 Мои параметры» — посмотреть последние замеры тела из Gym-Stat.\n"
+                "• «📊 Статистика» — перейти к диаграммам по упражнениям,"
+                " тренировкам и весу на сайте Gym-Stat.\n"
             )
 
         await update.message.reply_text(
@@ -46,7 +48,7 @@ async def settings(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 " что-то пусто, заполните раздел «Личные данные».\n"
                 f"{api_hint}"
                 "• «⚖️ Данные взвешивания» — история веса (активна после входа"
-                " в Gym-Stat).\n"
+                " в Gym-Stat). Ссылки откроются на сайте Gym-Stat.\n"
                 "• «🔙 Назад в главное меню» — вернуться к основным кнопкам.\n\n"
                 "<i>Совет: если бот попросил авторизоваться, выполните /login"
                 " или используйте кнопку «Войти» в режиме Gym-Stat.</i>"

--- a/bot/config/settings.py
+++ b/bot/config/settings.py
@@ -30,6 +30,8 @@ str: Конфигурация OAuth для авторизации в Sberbank AP
 
 # Базовый URL API Gym-Stat
 GYMSTAT_API_URL = environ.get('GYMSTAT_API_URL', 'https://api.gym-stat.ru')
+# Базовый URL веб-версии Gym-Stat
+GYMSTAT_WEB_URL = environ.get('GYMSTAT_WEB_URL', 'https://gym-stat.ru')
 # Ключ для шифрования токенов
 ENCRYPT_KEY = environ.get('ENCRYPT_KEY', Fernet.generate_key().decode())
 """

--- a/bot/handlers/misc_handlers.py
+++ b/bot/handlers/misc_handlers.py
@@ -21,6 +21,7 @@ from bot.keyboards.main_menu import get_main_menu
 from bot.keyboards.settings_menu import get_settings_menu
 from bot.keyboards.personal_data_menu import get_personal_data_menu
 from bot.keyboards.training_settings_menu import get_training_settings_menu
+from bot.keyboards.stats_menu import get_stats_menu
 from bot.utils.db_utils import get_user_mode
 from bot.utils.logger import setup_logging
 from bot.config.settings import DB_PATH
@@ -78,6 +79,8 @@ async def show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         if mode == 'api':
             api_hint = (
                 "• «📏 Мои параметры» — посмотреть замеры тела, сохранённые в Gym-Stat.\n"
+                "• «📊 Статистика» — перейти к диаграммам по упражнениям,"
+                " тренировкам и весу на сайте Gym-Stat.\n"
             )
 
         await query.message.edit_text(
@@ -87,7 +90,8 @@ async def show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
                 "• «📋 Личные данные» — обнови имя, возраст, вес, рост и пол.\n"
                 "• «👤 Показать профиль» — просмотр сохранённых сведений.\n"
                 f"{api_hint}"
-                "• «⚖️ Данные взвешивания» — история веса из Gym-Stat.\n"
+                "• «⚖️ Данные взвешивания» — история веса из Gym-Stat."
+                " Ссылки откроются на сайте Gym-Stat.\n"
                 "• «🔙 Назад в главное меню» — вернуться к основным действиям.\n\n"
                 "Если разделы пустые, начни с заполнения личных данных или"
                 " авторизуйся через /login для синхронизации с сайтом."
@@ -133,6 +137,64 @@ async def show_personal_data_menu(update: Update, context: ContextTypes.DEFAULT_
         ),
         parse_mode="HTML",
         reply_markup=get_personal_data_menu()
+    )
+    context.user_data['conversation_active'] = False
+    return ConversationHandler.END
+
+
+async def show_statistics_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Показывает меню статистики Gym-Stat."""
+
+    query = update.callback_query
+    if not query:
+        logger.error("Отсутствует callback_query при показе статистики")
+        return ConversationHandler.END
+
+    await query.answer()
+
+    user_id = query.from_user.id
+    logger.info("Пользователь %s открыл раздел статистики", user_id)
+
+    try:
+        mode = await get_user_mode(user_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Не удалось определить режим пользователя %s: %s", user_id, exc)
+        try:
+            await query.message.edit_text(
+                "⚠️ Не удалось определить режим работы. Попробуйте позже.",
+                reply_markup=get_settings_menu(),
+            )
+        except Exception as reply_error:  # noqa: BLE001
+            logger.error(
+                "Ошибка при отправке уведомления пользователю %s: %s",
+                user_id,
+                reply_error,
+            )
+        context.user_data['conversation_active'] = False
+        return ConversationHandler.END
+
+    if mode != "api":
+        await query.message.edit_text(
+            "ℹ️ Статистика доступна после входа в Gym-Stat. Выполните /login"
+            " и попробуйте снова.",
+            parse_mode="HTML",
+            reply_markup=get_settings_menu(mode=mode),
+        )
+        context.user_data['conversation_active'] = False
+        return ConversationHandler.END
+
+    await query.message.edit_text(
+        (
+            "📊 <b>Статистика Gym-Stat</b>\n"
+            "• «По упражнениям» — динамика нагрузок по каждому упражнению.\n"
+            "• «По тренировкам» — суммарные показатели по занятиям.\n"
+            "• «По весу» — графики изменения массы тела.\n"
+            "Ссылки откроются в браузере на сайте Gym-Stat. Если окно не"
+            " открывается автоматически, воспользуйтесь кнопкой повторно"
+            " или скопируйте адрес вручную."
+        ),
+        parse_mode="HTML",
+        reply_markup=get_stats_menu(),
     )
     context.user_data['conversation_active'] = False
     return ConversationHandler.END

--- a/bot/keyboards/settings_menu.py
+++ b/bot/keyboards/settings_menu.py
@@ -27,13 +27,22 @@ def get_settings_menu(mode: str = "local"):
         keyboard.append([
             InlineKeyboardButton("📏 Мои параметры", callback_data="body_params")
         ])
-
-    keyboard.append([
-        InlineKeyboardButton(
-            "⚖️ Данные взвешивания",
-            callback_data='weight_data_page_1'
-        )
-    ])
+        keyboard.append([
+            InlineKeyboardButton("📊 Статистика", callback_data='statistics')
+        ])
+        keyboard.append([
+            InlineKeyboardButton(
+                "⚖️ Данные взвешивания",
+                callback_data='weight_data_page_1'
+            )
+        ])
+    else:
+        keyboard.append([
+            InlineKeyboardButton(
+                "⚖️ Данные взвешивания",
+                callback_data='weight_data_page_1'
+            )
+        ])
     keyboard.append([
         InlineKeyboardButton(
             "🔙 Назад в главное меню", callback_data='main_menu'

--- a/bot/keyboards/stats_menu.py
+++ b/bot/keyboards/stats_menu.py
@@ -1,0 +1,46 @@
+# bot/keyboards/stats_menu.py
+"""Клавиатура раздела статистики Gym-Stat."""
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from bot.config.settings import GYMSTAT_WEB_URL
+
+
+def _build_url(segment: str) -> str:
+    """Формирует абсолютный URL до раздела статистики Gym-Stat."""
+    base_url = GYMSTAT_WEB_URL.rstrip('/')
+    return f"{base_url}/stats/{segment}".rstrip('/')
+
+
+def get_stats_menu() -> InlineKeyboardMarkup:
+    """Создаёт клавиатуру со ссылками на статистику Gym-Stat."""
+    keyboard = [
+        [
+            InlineKeyboardButton(
+                "По упражнениям",
+                url=_build_url('exercises')
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "По тренировкам",
+                url=_build_url('workouts')
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "По весу",
+                url=_build_url('weight')
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "🔙 Назад",
+                callback_data='settings'
+            )
+        ],
+    ]
+    return InlineKeyboardMarkup(keyboard)
+
+
+__all__ = ["get_stats_menu"]

--- a/bot/main.py
+++ b/bot/main.py
@@ -49,6 +49,7 @@ from bot.handlers.profile_display import show_profile
 from bot.handlers.misc_handlers import (
     start_training,
     show_settings,
+    show_statistics_menu,
     show_personal_data_menu,
     show_training_settings,
     return_to_main_menu
@@ -282,6 +283,7 @@ def main() -> None:
             CallbackQueryHandler(show_personal_data_menu, pattern='^personal_data$'),
             CallbackQueryHandler(show_training_settings, pattern='^training_settings$'),
             CallbackQueryHandler(return_to_main_menu, pattern='^main_menu$'),
+            CallbackQueryHandler(show_statistics_menu, pattern='^statistics$'),
             CallbackQueryHandler(show_weight_data, pattern='^weight_data_page_\\d+$'),
             CallbackQueryHandler(set_name_callback, pattern='^set_name$'),
             CallbackQueryHandler(set_age_callback, pattern='^set_age$'),


### PR DESCRIPTION
## Summary
- add a configurable Gym-Stat web URL and expose a statistics inline keyboard
- extend settings guidance with the new statistics section and Gym-Stat link hints
- register the statistics handler and callbacks inside the main conversation flow

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68da287a9e608320a7504742aef8ea1b