### PR TITLE
Clean up user messages during workout and exercise creation

### DIFF
--- a/bot/handlers/exercises.py
+++ b/bot/handlers/exercises.py
@@ -47,6 +47,7 @@ from bot.keyboards.exercises_menu import (
 from bot.utils.api_session import get_valid_access_token
 from bot.utils.db_utils import get_user_mode
 from bot.utils.logger import setup_logging
+from bot.utils.message_deletion import schedule_message_deletion
 
 
 logger = setup_logging()
@@ -61,6 +62,9 @@ _EXERCISE_UUID_KEY = "exercise_uuid"
 _EXERCISE_CACHE_KEY = "exercises_cache"
 _EXERCISE_GROUP_CHOICES_KEY = "exercise_group_choices"
 _EXERCISE_GROUP_UPDATE_CHOICES_KEY = "exercise_group_update_choices"
+
+
+_USER_INPUT_DELETE_DELAY = 15
 
 
 _DESCRIPTION_INTRO = (
@@ -627,8 +631,18 @@ async def handle_exercise_name_input(update: Update, context: ContextTypes.DEFAU
         return EXERCISE_SET_NAME
 
     name = message.text.strip()
+    user_chat_id = message.chat_id
+    user_message_id = message.message_id
     if not name:
-        await message.reply_text("⚠️ Название не может быть пустым. Укажите другое значение.")
+        warning_message = await message.reply_text(
+            "⚠️ Название не может быть пустым. Укажите другое значение."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, warning_message.message_id],
+            user_chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return EXERCISE_SET_NAME
 
     draft = context.user_data.get(_EXERCISE_DRAFT_KEY)
@@ -643,10 +657,23 @@ async def handle_exercise_name_input(update: Update, context: ContextTypes.DEFAU
         "Можно указать краткую подсказку. Отправьте «-», чтобы оставить пустым."
     )
     if prompt:
-        chat_id, message_id = prompt
-        await _safe_edit_message(context, chat_id, message_id, text=text)
+        prompt_chat_id, message_id = prompt
+        await _safe_edit_message(context, prompt_chat_id, message_id, text=text)
     else:
-        await message.reply_text(text, parse_mode="HTML")
+        prompt_message = await message.reply_text(text, parse_mode="HTML")
+        schedule_message_deletion(
+            context,
+            [prompt_message.message_id],
+            user_chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
+
+    schedule_message_deletion(
+        context,
+        [user_message_id],
+        user_chat_id,
+        delay=_USER_INPUT_DELETE_DELAY,
+    )
 
     context.user_data["conversation_active"] = True
     return EXERCISE_SET_DESCRIPTION
@@ -664,10 +691,20 @@ async def handle_exercise_description_input(
     if description == "-":
         description = ""
 
+    user_chat_id = message.chat_id
+    user_message_id = message.message_id
     draft = context.user_data.get(_EXERCISE_DRAFT_KEY)
     name = draft.get("name") if isinstance(draft, dict) else None
     if not name:
-        await message.reply_text("⚠️ Не удалось определить название упражнения. Попробуйте снова.")
+        warning_message = await message.reply_text(
+            "⚠️ Не удалось определить название упражнения. Попробуйте снова."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, warning_message.message_id],
+            user_chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         _reset_exercise_flow(context)
         context.user_data["conversation_active"] = False
         return ConversationHandler.END
@@ -675,14 +712,30 @@ async def handle_exercise_description_input(
     user_id = message.from_user.id
     mode = await get_user_mode(user_id)
     if mode != "api":
-        await message.reply_text("Для создания упражнений необходимо включить режим Gym-Stat.")
+        info_message = await message.reply_text(
+            "Для создания упражнений необходимо включить режим Gym-Stat."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, info_message.message_id],
+            user_chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         _reset_exercise_flow(context)
         context.user_data["conversation_active"] = False
         return ConversationHandler.END
 
     token = await get_valid_access_token(user_id)
     if not token:
-        await message.reply_text("🔐 Пожалуйста, выполните вход через /login и повторите попытку.")
+        info_message = await message.reply_text(
+            "🔐 Пожалуйста, выполните вход через /login и повторите попытку."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, info_message.message_id],
+            user_chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         _reset_exercise_flow(context)
         context.user_data["conversation_active"] = False
         return ConversationHandler.END
@@ -694,13 +747,27 @@ async def handle_exercise_description_input(
     if not isinstance(groups, list) or not groups:
         groups = await _fetch_groups(context, user_id, token)
         if groups is None:
-            await message.reply_text("❌ Не удалось получить список групп. Попробуйте позже.")
+            error_message = await message.reply_text(
+                "❌ Не удалось получить список групп. Попробуйте позже."
+            )
+            schedule_message_deletion(
+                context,
+                [user_message_id, error_message.message_id],
+                user_chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             _reset_exercise_flow(context)
             context.user_data["conversation_active"] = False
             return ConversationHandler.END
         if not groups:
-            await message.reply_text(
+            info_message = await message.reply_text(
                 "⚠️ Прежде чем создать упражнение, добавьте хотя бы одну группу в разделе «Группы упражнений»."
+            )
+            schedule_message_deletion(
+                context,
+                [user_message_id, info_message.message_id],
+                user_chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
             )
             _reset_exercise_flow(context)
             context.user_data["conversation_active"] = False
@@ -732,6 +799,13 @@ async def handle_exercise_description_input(
             parse_mode="HTML",
             reply_markup=build_exercise_group_selection_keyboard(groups),
         )
+
+    schedule_message_deletion(
+        context,
+        [user_message_id],
+        user_chat_id,
+        delay=_USER_INPUT_DELETE_DELAY,
+    )
 
     context.user_data["conversation_active"] = False
     return ConversationHandler.END
@@ -1558,9 +1632,19 @@ async def handle_exercise_group_name_input(update: Update, context: ContextTypes
     if not message or not message.text:
         return EXERCISE_GROUP_SET_NAME
 
+    chat_id = message.chat_id
+    user_message_id = message.message_id
     name = message.text.strip()
     if not name:
-        await message.reply_text("⚠️ Название не может быть пустым. Укажите другое значение.")
+        warning_message = await message.reply_text(
+            "⚠️ Название не может быть пустым. Укажите другое значение."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, warning_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return EXERCISE_GROUP_SET_NAME
 
     draft = context.user_data.get(_DRAFT_KEY, {})
@@ -1580,6 +1664,13 @@ async def handle_exercise_group_name_input(update: Update, context: ContextTypes
             ),
         )
 
+    schedule_message_deletion(
+        context,
+        [user_message_id],
+        chat_id,
+        delay=_USER_INPUT_DELETE_DELAY,
+    )
+
     context.user_data["conversation_active"] = True
     return EXERCISE_GROUP_SET_DESCRIPTION
 
@@ -1596,10 +1687,20 @@ async def handle_exercise_group_description_input(
     if description == "-":
         description = ""
 
+    chat_id = message.chat_id
+    user_message_id = message.message_id
     draft = context.user_data.get(_DRAFT_KEY)
     name = draft.get("name") if isinstance(draft, dict) else None
     if not name:
-        await message.reply_text("⚠️ Не удалось определить название группы. Попробуйте снова.")
+        error_message = await message.reply_text(
+            "⚠️ Не удалось определить название группы. Попробуйте снова."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, error_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         _reset_flow(context)
         context.user_data["conversation_active"] = False
         return ConversationHandler.END
@@ -1607,14 +1708,30 @@ async def handle_exercise_group_description_input(
     user_id = message.from_user.id
     mode = await get_user_mode(user_id)
     if mode != "api":
-        await message.reply_text("Для создания групп необходимо включить режим Gym-Stat.")
+        info_message = await message.reply_text(
+            "Для создания групп необходимо включить режим Gym-Stat."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, info_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         _reset_flow(context)
         context.user_data["conversation_active"] = False
         return ConversationHandler.END
 
     token = await get_valid_access_token(user_id)
     if not token:
-        await message.reply_text("🔐 Пожалуйста, выполните вход через /login и повторите попытку.")
+        info_message = await message.reply_text(
+            "🔐 Пожалуйста, выполните вход через /login и повторите попытку."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, info_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         _reset_flow(context)
         context.user_data["conversation_active"] = False
         return ConversationHandler.END
@@ -1624,7 +1741,15 @@ async def handle_exercise_group_description_input(
         response = await api_create_exercise_group(token, payload)
     except httpx.RequestError as exc:
         logger.error("Ошибка создания группы для пользователя %s: %s", user_id, exc)
-        await message.reply_text("❌ Не удалось создать группу упражнений. Попробуйте позже.")
+        error_message = await message.reply_text(
+            "❌ Не удалось создать группу упражнений. Попробуйте позже."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, error_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         _reset_flow(context)
         context.user_data["conversation_active"] = False
         return ConversationHandler.END
@@ -1635,20 +1760,28 @@ async def handle_exercise_group_description_input(
             response.status_code,
             response.text,
         )
-        await message.reply_text("❌ Gym-Stat вернул ошибку при создании группы. Проверьте данные и попробуйте снова.")
+        error_message = await message.reply_text(
+            "❌ Gym-Stat вернул ошибку при создании группы. Проверьте данные и попробуйте снова."
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, error_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         _reset_flow(context)
         context.user_data["conversation_active"] = False
         return ConversationHandler.END
 
     prompt = context.user_data.get(_PROMPT_KEY)
-    chat_id, message_id = prompt if prompt else (message.chat_id, None)
+    prompt_chat_id, message_id = prompt if prompt else (message.chat_id, None)
 
     groups = await _fetch_groups(context, user_id, token) or []
 
     if message_id is not None:
         await _safe_edit_message(
             context,
-            chat_id,
+            prompt_chat_id,
             message_id,
             text=_build_groups_text(groups),
             reply_markup=build_exercise_groups_keyboard(groups),
@@ -1659,6 +1792,13 @@ async def handle_exercise_group_description_input(
             parse_mode="HTML",
             reply_markup=build_exercise_groups_keyboard(groups),
         )
+
+    schedule_message_deletion(
+        context,
+        [user_message_id],
+        chat_id,
+        delay=_USER_INPUT_DELETE_DELAY,
+    )
 
     _reset_flow(context)
     context.user_data["conversation_active"] = False

--- a/bot/handlers/workouts.py
+++ b/bot/handlers/workouts.py
@@ -44,6 +44,8 @@ _DATE_FORMATS = (
     "%Y-%m-%dT%H:%M:%S",
 )
 
+_USER_INPUT_DELETE_DELAY = 15
+
 
 async def show_workouts_menu(
     update: Update, context: ContextTypes.DEFAULT_TYPE
@@ -382,100 +384,165 @@ async def handle_workout_creation_input(
     draft: Dict[str, Any] = context.user_data.get(_WORKOUT_DRAFT_KEY, {})
     token: Optional[str] = context.user_data.get("workout_token")
 
+    user_message = update.message
+    if not user_message or user_message.text is None:
+        return WORKOUT_CREATION
+
+    chat_id = user_message.chat_id
+    user_message_id = user_message.message_id
+    text = user_message.text.strip()
+
     if stage is None or draft is None or token is None:
-        await update.message.reply_text(
+        error_message = await user_message.reply_text(
             "⚠️ Возникла ошибка. Попробуйте начать создание тренировки заново.",
+        )
+        schedule_message_deletion(
+            context,
+            [user_message_id, error_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
         )
         context.user_data["conversation_active"] = False
         _reset_workout_flow(context)
         return ConversationHandler.END
 
-    text = update.message.text.strip()
-    chat_id = update.message.chat_id
-
     if stage == "name":
         draft["name"] = text
         context.user_data[_WORKOUT_STAGE_KEY] = "description"
-        message = await update.message.reply_text(
+        prompt_message = await user_message.reply_text(
             (
                 "📝 <b>Добавьте описание тренировки</b>\n"
                 "Например: <code>Силовая работа с акцентом на базовые упражнения</code>."
             ),
             parse_mode="HTML",
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, prompt_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "description":
         draft["description"] = text
         context.user_data[_WORKOUT_STAGE_KEY] = "date"
-        message = await update.message.reply_text(
+        prompt_message = await user_message.reply_text(
             (
                 "📅 <b>Укажите дату тренировки</b> в формате"
                 " <code>гггг-мм-дд</code>."
             ),
             parse_mode="HTML",
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, prompt_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "date":
         parsed_date = _parse_user_date(text)
         if not parsed_date:
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Неверный формат даты. Используйте <code>гггг-мм-дд</code>.",
                 parse_mode="HTML",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
         draft["date"] = parsed_date
         context.user_data[_WORKOUT_STAGE_KEY] = "duration"
-        message = await update.message.reply_text(
+        prompt_message = await user_message.reply_text(
             "⏱️ <b>Укажите длительность тренировки</b> в минутах.",
             parse_mode="HTML",
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, prompt_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "duration":
         if not text.isdigit() or int(text) <= 0:
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Введите целое число минут больше нуля.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
         draft["duration"] = int(text)
         context.user_data[_WORKOUT_STAGE_KEY] = "calories"
-        message = await update.message.reply_text(
+        prompt_message = await user_message.reply_text(
             "🔥 <b>Укажите потраченные калории</b> (целое число).",
             parse_mode="HTML",
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, prompt_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "calories":
         if not text.isdigit() or int(text) < 0:
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Калории вводятся целым числом не меньше нуля.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
         draft["calories"] = int(text)
 
         exercises = await _fetch_exercises(token)
         if exercises is None:
-            await update.message.reply_text(
+            error_message = await user_message.reply_text(
                 "❌ Не удалось получить список упражнений. Попробуйте позже.",
+            )
+            schedule_message_deletion(
+                context,
+                [user_message_id, error_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
             )
             context.user_data["conversation_active"] = False
             _reset_workout_flow(context)
             return ConversationHandler.END
         if not exercises:
-            await update.message.reply_text(
+            info_message = await user_message.reply_text(
                 (
                     "📋 Сначала создайте хотя бы одно упражнение в разделе"
                     " «Упражнения», затем повторите создание тренировки."
                 )
+            )
+            schedule_message_deletion(
+                context,
+                [user_message_id, info_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
             )
             context.user_data["conversation_active"] = False
             _reset_workout_flow(context)
@@ -488,7 +555,7 @@ async def handle_workout_creation_input(
         }
         context.user_data.pop(_WORKOUT_CURRENT_SET_KEY, None)
         keyboard = build_add_set_keyboard()
-        message = await update.message.reply_text(
+        prompt_message = await user_message.reply_text(
             (
                 "💪 <b>Создать подход?</b>."
                 " После выбора бот попросит указать вес, количество повторов и интенсивность."
@@ -496,79 +563,133 @@ async def handle_workout_creation_input(
             parse_mode="HTML",
             reply_markup=keyboard,
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, prompt_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "add_set_prompt":
-        message = await update.message.reply_text(
+        info_message = await user_message.reply_text(
             "ℹ️ Используйте кнопки «Да» или «Нет», чтобы добавить подход или завершить создание.",
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, info_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id, info_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "exercise":
-        message = await update.message.reply_text(
+        info_message = await user_message.reply_text(
             "ℹ️ Выберите упражнение, используя кнопки под предыдущим сообщением.",
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, info_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id, info_message.message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "weight":
         current_set = context.user_data.get(_WORKOUT_CURRENT_SET_KEY)
         if not current_set or not current_set.get("exerciseId"):
             context.user_data[_WORKOUT_STAGE_KEY] = "exercise"
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Сначала выберите упражнение с помощью кнопок.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
 
         weight = _parse_number(text)
         if weight is None or weight <= 0:
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Вес указывается положительным числом. Пример: 60 или 60.5",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
 
         counts = current_set.setdefault("counts", {})
         counts["weight"] = weight
         context.user_data[_WORKOUT_STAGE_KEY] = "reps"
-        message = await update.message.reply_text(
+        prompt_message = await user_message.reply_text(
             "🔢 Укажите количество повторов для подхода (целое число).",
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, prompt_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "reps":
         current_set = context.user_data.get(_WORKOUT_CURRENT_SET_KEY)
         if not current_set or not current_set.get("exerciseId"):
             context.user_data[_WORKOUT_STAGE_KEY] = "exercise"
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Сначала выберите упражнение с помощью кнопок.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
 
         counts = current_set.setdefault("counts", {})
         if counts.get("weight") is None:
             context.user_data[_WORKOUT_STAGE_KEY] = "weight"
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Сначала укажите вес для подхода.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
 
         if not text.isdigit() or int(text) <= 0:
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Повторы вводятся целым числом больше нуля.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
 
         counts["reps"] = int(text)
         context.user_data[_WORKOUT_STAGE_KEY] = "intensity"
-        message = await update.message.reply_text(
+        prompt_message = await user_message.reply_text(
             (
                 "💥 Укажите степень интенсивности (например: <code>no-failure</code>,"
                 " <code>muscle-failure</code>, <code>technical-failure</code>)."
@@ -576,33 +697,57 @@ async def handle_workout_creation_input(
             ),
             parse_mode="HTML",
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, prompt_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
     if stage == "intensity":
         current_set = context.user_data.get(_WORKOUT_CURRENT_SET_KEY)
         if not current_set or not current_set.get("exerciseId"):
             context.user_data[_WORKOUT_STAGE_KEY] = "exercise"
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Сначала выберите упражнение с помощью кнопок.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
 
         counts = current_set.setdefault("counts", {})
         if counts.get("weight") is None:
             context.user_data[_WORKOUT_STAGE_KEY] = "weight"
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Сначала укажите вес для подхода.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
         if counts.get("reps") is None:
             context.user_data[_WORKOUT_STAGE_KEY] = "reps"
-            message = await update.message.reply_text(
+            warning_message = await user_message.reply_text(
                 "⚠️ Сначала введите количество повторов.",
             )
-            _remember_prompt(context, message.message_id, chat_id)
+            _remember_prompt(context, warning_message.message_id, chat_id)
+            schedule_message_deletion(
+                context,
+                [user_message_id, warning_message.message_id],
+                chat_id,
+                delay=_USER_INPUT_DELETE_DELAY,
+            )
             return WORKOUT_CREATION
 
         intensity_value = text.strip()
@@ -629,15 +774,27 @@ async def handle_workout_creation_input(
         context.user_data.pop(_WORKOUT_CURRENT_SET_KEY, None)
         context.user_data[_WORKOUT_STAGE_KEY] = "add_set_prompt"
         keyboard = build_add_set_keyboard()
-        message = await update.message.reply_text(
+        prompt_message = await user_message.reply_text(
             "✅ Подход добавлен. Хотите создать ещё один?",
             reply_markup=keyboard,
         )
-        _remember_prompt(context, message.message_id, chat_id)
+        _remember_prompt(context, prompt_message.message_id, chat_id)
+        schedule_message_deletion(
+            context,
+            [user_message_id],
+            chat_id,
+            delay=_USER_INPUT_DELETE_DELAY,
+        )
         return WORKOUT_CREATION
 
-    await update.message.reply_text(
+    warning_message = await user_message.reply_text(
         "⚠️ Неизвестный шаг. Попробуйте начать заново.",
+    )
+    schedule_message_deletion(
+        context,
+        [user_message_id, warning_message.message_id],
+        chat_id,
+        delay=_USER_INPUT_DELETE_DELAY,
     )
     context.user_data["conversation_active"] = False
     _reset_workout_flow(context)


### PR DESCRIPTION
## Summary
- schedule deletion of user inputs and related warnings when entering exercise details
- apply the same cleanup for each step of the workout creation flow and reuse a shared delay constant

## Testing
- python -m compileall bot/handlers/exercises.py bot/handlers/workouts.py

------
https://chatgpt.com/codex/tasks/task_e_68dac8cd0f4883209c1fd23ffb010cd9